### PR TITLE
Shrink

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -6,3 +6,4 @@ path = "src"
 
 [dependencies]
 mathlib = { git = "https://github.com/leanprover-community/mathlib", rev = "30a731ca565b92955e40274652f4c2b6f4db79f4" }
+minif2f = { git = "https://github.com/openai/miniF2F.git", rev = "9b00e8ba0b52836177fb3a6a0d1a5a945144bb61" }

--- a/src/repl.lean
+++ b/src/repl.lean
@@ -321,7 +321,6 @@ meta def collect_proof_steps (σ : LeanREPLState) (sid tsid : string) : io (list
 meta def handle_shrink_proof
   (req : LeanREPLRequest)
   : LeanREPL LeanREPLResponse := do {
-  state_t.lift $ io.print_ln "handle_shrink_proof",
   σ ← get,
   match (σ.get_ts req.sid req.tsid) with
   | none := do {

--- a/src/repl.lean
+++ b/src/repl.lean
@@ -329,7 +329,7 @@ meta def handle_shrink_proof
     pure ⟨none, none, none, some err.to_string, []⟩
   }
   | (some ts_final) := do {
-    state_t.lift $ io.run_tac ts_final (do tactic.trace_state, gs ← tactic.get_goals, tactic.trace gs.length, tactic.done),
+    state_t.lift $ io.run_tac ts_final tactic.done,
     steps ← state_t.lift $ collect_proof_steps σ req.sid req.tsid,
     new_steps ← state_t.lift (shrink_proof steps),
     pure ⟨none, none, none, none, new_steps.map (λ ⟨_, action, _⟩, action)⟩

--- a/src/repl.lean
+++ b/src/repl.lean
@@ -366,7 +366,6 @@ meta def handle_try_finish
       -- TODO: refactor so that finalizing a proof is a separate top-level call
       goals ← state_t.lift $ io.run_tac ts' tactic.get_goals,
       if goals.empty then do {
-        state_t.lift $ io.print_ln "FINISH",
         r ← finalize_proof { req with tac := action } ts',
         match r.error with
         | none := do {

--- a/src/tools/filter_decls.lean
+++ b/src/tools/filter_decls.lean
@@ -17,34 +17,37 @@ end io
 
 setup_tactic_parser
 
-meta def parse_decl_nm_and_open_ns : string → tactic (name × list name) := λ inp,
-flip lean.parser.run_with_input inp $ prod.mk <$> iterate_until ident (λ nm, pure ∘ bnot $ nm = name.anonymous) 100 <*> many ident
+-- Expected file format:
+-- <decl>, <import> ... <import>, <open> ... <open>
 
--- #eval (["foo bar baz\n", "baz baz baz\n", "a b c d e\n"].mmap $ io.run_tactic' ∘ parse_decl_nm_and_open_ns) >>= λ x, io.put_str_ln' format!"{x}"
+meta def parse_decl_and_metadata (input : string) : tactic (name × list name × list name) := do
+ flip lean.parser.run_with_input input $ do
+  name ← ident,
+  tk ",",
+  imports ← many ident,
+  tk ",",
+  opens ← many ident,
+  pure (name, imports, opens)
 
 end
 
 def for_ {m α β} [monad m] (xs : list α) (body : α → m β) := list.mmap' body xs
-
 
 meta def main_aux (names_file : string) (dest : string) : io unit := do {
   nm_strs ← (io.mk_file_handle names_file io.mode.read >>= λ f,
     (string.split (λ c, c = '\n') <$> buffer.to_string <$> io.fs.read_to_end f)),
 
   let nm_strs := nm_strs.filter (λ x : string, x.length > 0),
-  nms : list (name × list name) ← io.run_tactic'' $ nm_strs.mmap parse_decl_nm_and_open_ns,
+  nms : list (name × list name × list name) ← io.run_tactic'' $ nm_strs.mmap parse_decl_and_metadata,
   dest_handle ← io.mk_file_handle dest io.mode.write,
 
   io.run_tactic'' $ do {
     env ← tactic.get_env,
-    for_ nms $ λ ⟨nm, open_ns⟩, tactic.try $ do {
+    for_ (nm_strs.zip nms) $ λ ⟨nm_str, ⟨nm, imports, open_ns⟩⟩, tactic.try $ do {
       decl ← env.get nm,
       if decl.is_theorem then do {
         tactic.trace format! "[filter_defs] KEEPING {nm.to_string}",
-        tactic.unsafe_run_io $
-          io.fs.put_str_ln_flush
-            dest_handle
-              (nm.to_string ++ " " ++ (" ".intercalate $ name.to_string <$> open_ns))
+        tactic.unsafe_run_io $ io.fs.put_str_ln_flush dest_handle nm_str
       } else do {
         tactic.trace format! "[filter_defs] DISCARDING {nm.to_string}",
         pure ()

--- a/src/tools/shrink_proof.lean
+++ b/src/tools/shrink_proof.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2022 OpenAI. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Daniel Selsam
+
+Simple, barebones heuristic proof-minimization.
+-/
+import util.io
+import data.list.basic
+import util.tactic
+import tactic.gptf.utils.util
+
+meta def io.run_tac {α : Type} (ts : tactic_state) (tac : tactic α) : io α :=
+  io.run_tactic'' (do tactic.write ts, tac)
+
+meta def expr.mvar_id : expr → name
+| (expr.mvar unique _ _) := unique
+| _ := `error.not_an_mvar
+
+meta def build_proof_trace (ts₀ : tactic_state) (steps : list (string × tactic_state)) : list (tactic_state × string × tactic_state) :=
+  list.reverse $ prod.snd $ @list.foldl (tactic_state × list (tactic_state × string × tactic_state)) 
+    (string × tactic_state) 
+    (λ ⟨ts_prev, new_steps⟩ ⟨action, ts_next⟩, (ts_next, new_steps.cons (ts_prev, action, ts_next))) 
+    (ts₀, []) 
+    steps 
+
+/--
+Consider the following proof:
+```
+have h1 : ... := ...,
+have h2 : ... h1 ... := ...,
+have h3 : ... h1 ... := ...,
+have h4 : ... h2 ... := ...,
+exact h3
+```
+Here `h2` and `h4` can be safely removed. 
+
+We detect removable `have`s by proceeding in reverse order.
+For a given `have` statement, we can tell if it appears in the resulting proof
+by checking the proof term in the metavariable context of the final tactic state.
+-/
+
+meta def strip_unused_haves (ts_final : tactic_state) (steps : list (tactic_state × string × tactic_state)) : io (list (tactic_state × string × tactic_state)) := do {
+  ⟨bad_idx, bad_idx_num_goals⟩ ← steps.enum.reverse.mfirst (λ ⟨idx, ⟨ts1, action, ts2⟩⟩, do {
+    if action.to_list.take 5 = "have ".to_list then do {
+      gs1 ← io.run_tac ts1 tactic.get_goals,
+      gs2 ← io.run_tac ts2 tactic.get_goals,
+      if gs1.length + 1 = gs2.length ∧ gs1.drop 1 = gs2.drop 2 then do {
+        -- `have` step without proof
+        let goal_with_assumption := gs2.nth_le 1 sorry,
+        assumption ← io.run_tac ts2 (do tactic.set_goals [goal_with_assumption], hs ← tactic.local_context, pure (hs.last sorry)),
+        proof_of_goal_with_assumption ← io.run_tac ts_final (tactic.instantiate_mvars goal_with_assumption),
+        if not (expr.occurs assumption proof_of_goal_with_assumption) then 
+          pure (idx, gs1.length)
+        else io.fail "`have` step is used"
+      } 
+      else io.fail "blah"
+    }
+    else
+      io.fail "no haves"
+    }
+  ),
+
+  num_goals_per_step : list ℕ ← steps.mmap (λ ⟨ts1, action, ts2⟩, io.run_tac ts1 (do gs ← tactic.get_goals, pure gs.length)),
+  let resume_idx : ℕ := num_goals_per_step.enum.find_index (λ idx__num_goals, idx__num_goals.fst > bad_idx ∧ idx__num_goals.snd = bad_idx_num_goals),
+  pure (steps.take bad_idx ++ steps.drop resume_idx)
+}
+
+meta def shrink_proof_aux : list (tactic_state × string × tactic_state) → io (list (tactic_state × string × tactic_state)) 
+| [] := io.fail "shrink_proof called on empty proof"
+| steps := do
+  let ts_final := (steps.last sorry).snd.snd,
+  io.run_tac ts_final tactic.done,
+  ⟨fewer_steps, success⟩ ← io.catch (do steps ← strip_unused_haves ts_final steps, pure (steps, tt)) (λ e, pure (steps, ff)),
+  if success then shrink_proof_aux fewer_steps else pure fewer_steps
+  
+meta def shrink_proof (ts₀ : tactic_state) (steps : list (string × tactic_state)) : io (list (tactic_state × string × tactic_state)) :=
+  shrink_proof_aux (build_proof_trace ts₀ steps)

--- a/src/tools/shrink_proof.lean
+++ b/src/tools/shrink_proof.lean
@@ -56,7 +56,11 @@ meta def strip_unused_haves (ts_final : tactic_state) (steps : list (tactic_stat
 }
 
 meta def rerun_proof : tactic_state → list string → io (list (tactic_state × string × tactic_state))
-| ts1 [] := pure []
+| ts1 [] := do {
+  -- confirm that the proof has finished
+  io.run_tac ts1 tactic.done,
+  pure []
+}
 | ts1 (action::actions) := do 
   result_with_string ← io.run_tac ts1 (get_tac_and_capture_result action 5000),
   match result_with_string with

--- a/src/tools/shrink_proof.lean
+++ b/src/tools/shrink_proof.lean
@@ -8,7 +8,6 @@ Simple, barebones heuristic proof-minimization.
 import util.io
 import data.list.basic
 import util.tactic
-import tactic.gptf.utils.util
 
 /--
 Consider the following proof:
@@ -27,35 +26,61 @@ by checking the proof term in the metavariable context of the final tactic state
 -/
 
 meta def strip_unused_haves (ts_final : tactic_state) (steps : list (tactic_state × string × tactic_state)) : io (list (tactic_state × string × tactic_state)) := do {
-  ⟨bad_idx, bad_idx_num_goals⟩ ← steps.enum.reverse.mfirst (λ ⟨idx, ⟨ts1, action, ts2⟩⟩, do {
+  ⟨bad_idx, resume_goals⟩ ← steps.enum.reverse.mfirst (λ ⟨idx, ⟨ts1, action, ts2⟩⟩, do {
     if action.to_list.take 5 = "have ".to_list then do {
       gs1 ← io.run_tac ts1 tactic.get_goals,
       gs2 ← io.run_tac ts2 tactic.get_goals,
-      if gs1.length + 1 = gs2.length ∧ gs1.drop 1 = gs2.drop 2 then do {
-        -- `have` step without proof
-        let goal_with_assumption := gs2.nth_le 1 sorry,
-        assumption ← io.run_tac ts2 (do tactic.set_goals [goal_with_assumption], hs ← tactic.local_context, pure (hs.last sorry)),
-        proof_of_goal_with_assumption ← io.run_tac ts_final (tactic.instantiate_mvars goal_with_assumption),
-        if not (expr.occurs assumption proof_of_goal_with_assumption) then 
-          pure (idx, gs1.length)
-        else io.fail "`have` step is used"
-      } 
-      else io.fail "blah"
-    }
-    else
-      io.fail "no haves"
+      (goal_with_assumption, all_in_one) ← do {
+        -- `have` step with proof provided
+        if gs1.length = gs2.length ∧ gs1.drop 1 = gs2.drop 1 then pure (gs2.head, tt) 
+        -- `have` step without proof provided
+        else if gs1.length + 1 = gs2.length ∧ gs1.drop 1 = gs2.drop 2 then pure (gs2.nth_le 1 sorry, ff)
+        -- something weird, e.g. `have h : <prop>; swap`
+        else io.fail "weird `have`"
+      },
+      assumption ← io.run_tac ts2 $ do { 
+        tactic.set_goals [goal_with_assumption], 
+        hs ← tactic.local_context, 
+        if hs_nnil : hs ≠ [] then pure (hs.last hs_nnil) else tactic.fail "weird `have`"
+      },
+      proof_of_goal_with_assumption ← io.run_tac ts_final (tactic.instantiate_mvars goal_with_assumption),
+      if not (expr.occurs assumption proof_of_goal_with_assumption) then pure (idx, if all_in_one then gs2 else gs2.drop 1) else io.fail "`have` step is used"
+    } else
+      io.fail "not a `have` step"
     }
   ),
 
-  num_goals_per_step : list ℕ ← steps.mmap (λ ⟨ts1, action, ts2⟩, io.run_tac ts1 (do gs ← tactic.get_goals, pure gs.length)),
-  let resume_idx : ℕ := num_goals_per_step.enum.find_index (λ idx__num_goals, idx__num_goals.fst > bad_idx ∧ idx__num_goals.snd = bad_idx_num_goals),
-  pure (steps.take bad_idx ++ steps.drop resume_idx)
+  goals_per_step : list (list expr) ← steps.mmap (λ ⟨ts1, action, ts2⟩, io.run_tac ts1 tactic.get_goals),
+  let resume_idx : ℕ := goals_per_step.enum.find_index (λ idx__goals, idx__goals.fst > bad_idx ∧ idx__goals.snd = resume_goals),
+  if resume_idx = steps.length then io.fail "weird `have`, possible swap" else pure (steps.take bad_idx ++ steps.drop resume_idx)
 }
+
+meta def rerun_proof : tactic_state → list string → io (list (tactic_state × string × tactic_state))
+| ts1 [] := pure []
+| ts1 (action::actions) := do 
+  result_with_string ← io.run_tac ts1 (get_tac_and_capture_result action 5000),
+  match result_with_string with
+  -- The tactic application was successful.
+  | interaction_monad.result.success _ ts2 := do {
+    rest ← rerun_proof ts2 actions,
+    pure $ (ts1, action, ts2) :: rest
+  }
+  | _ := io.fail "failed to rerun proof"
+  end
 
 meta def shrink_proof : list (tactic_state × string × tactic_state) → io (list (tactic_state × string × tactic_state)) 
 | [] := io.fail "shrink_proof called on empty proof"
-| steps := do
+| steps@(step::rest) := do
   let ts_final := (steps.last sorry).snd.snd,
-  io.run_tac ts_final (do tactic.trace_state, tactic.done),
+  io.run_tac ts_final tactic.done,
   ⟨fewer_steps, success⟩ ← io.catch (do steps ← strip_unused_haves ts_final steps, pure (steps, tt)) (λ e, pure (steps, ff)),
-  if success then shrink_proof fewer_steps else pure fewer_steps
+  let ts_start := step.fst,
+  if success then do {
+    io.catch (do {
+      steps ← rerun_proof ts_start $ fewer_steps.map (λ ⟨_, action, _⟩, action),
+      shrink_proof steps
+    }) (λ e, pure steps)
+  }
+  else
+    pure steps
+

--- a/src/tools/try_finish.lean
+++ b/src/tools/try_finish.lean
@@ -14,20 +14,18 @@ meta def try_finish_tactics : list (tactic unit × string) := [
   (`[refl], "refl"),
   (`[exact dec_trivia], "exact dec_trivial"),
   (`[assumption], "assumption"),
-  (`[simp], "simp"),    
-  (`[dsimp], "dsimp"),    
-  (`[norm_num], "norm_num"),    
+  (`[simp], "simp"),
+  (`[dsimp], "dsimp"),
+  (`[norm_num], "norm_num"),
   (`[ring], "ring"),
-  (`[simp [*]], "simp [*]"),    
+  (`[simp [*]], "simp [*]"),
   (`[linarith], "linarith")
 ]
-  
-meta def try_finish (ts : tactic_state) (timeout : nat := 1000) : io (option (string × tactic_state)) := do
-  try_finish_tactics.mfirst $ λ ⟨tac, tacString⟩, do {
-    io.run_tac ts $ do {
-      gs1 ← tactic.get_goals,
-      tactic.try_for_time timeout $ tactic.try_for 200000 (tactic.solve1 tac),
-      ts2 ← get,
-      pure (tacString, ts2)
-    }
-  }
+
+meta def try_finish (ts : tactic_state) (timeout : nat := 1000) : io (option (string × tactic_state)) :=
+  (try_finish_tactics.mfirst $ λ ⟨tac, tacString⟩, io.run_tac ts $ do {
+    gs1 ← tactic.get_goals,
+    tactic.try_for_time timeout $ tactic.try_for 200000 (tactic.solve1 tac),
+    ts2 ← get,
+    pure (tacString, ts2)
+  }) <|> pure none

--- a/src/tools/try_finish.lean
+++ b/src/tools/try_finish.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2022 OpenAI. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Daniel Selsam
+
+Simple "squeezing" finishing.
+-/
+import util.io
+import data.list.basic
+import util.tactic
+
+meta def try_finish_tactics : list (tactic unit × string) := [
+  (`[trivial], "trivial"),
+  (`[refl], "refl"),
+  (`[exact dec_trivia], "exact dec_trivial"),
+  (`[assumption], "assumption"),
+  (`[simp], "simp"),    
+  (`[dsimp], "dsimp"),    
+  (`[norm_num], "norm_num"),    
+  (`[ring], "ring"),
+  (`[simp [*]], "simp [*]"),    
+  (`[linarith], "linarith")
+]
+  
+meta def try_finish (ts : tactic_state) (timeout : nat := 1000) : io (option (string × tactic_state)) := do
+  try_finish_tactics.mfirst $ λ ⟨tac, tacString⟩, do {
+    io.run_tac ts $ do {
+      gs1 ← tactic.get_goals,
+      tactic.try_for_time timeout $ tactic.try_for 200000 (tactic.solve1 tac),
+      ts2 ← get,
+      pure (tacString, ts2)
+    }
+  }

--- a/src/util/io.lean
+++ b/src/util/io.lean
@@ -28,7 +28,6 @@ meta def run_tactic'' {α} (tac :tactic α) : io α := do {
   }
 }
 
-
 meta def fail' {α} (fmt : format) : io α := io.fail $ format.to_string fmt
 
 meta def put_str_ln' : Π (fmt : format), io unit := io.put_str_ln ∘ format.to_string

--- a/src/util/io.lean
+++ b/src/util/io.lean
@@ -21,7 +21,7 @@ meta def run_tactic'' {α} (tac :tactic α) : io α := do {
     | (exception m_fmt _ _) := do {
       let fmt_msg := (m_fmt.get_or_else (λ _, format!"n/a")) (),
       let msg := format!"[fatal] {fmt_msg}",
-      tactic.trace msg,
+      -- tactic.trace msg,
       tactic.fail msg
     }
     end

--- a/src/util/io.lean
+++ b/src/util/io.lean
@@ -28,9 +28,13 @@ meta def run_tactic'' {α} (tac :tactic α) : io α := do {
   }
 }
 
+
 meta def fail' {α} (fmt : format) : io α := io.fail $ format.to_string fmt
 
 meta def put_str_ln' : Π (fmt : format), io unit := io.put_str_ln ∘ format.to_string
+
+meta def run_tac {α : Type} (ts : tactic_state) (tac : tactic α) : io α :=
+  run_tactic'' (do tactic.write ts, tac)
 
 end io
 end io
@@ -42,3 +46,5 @@ meta def list.nth_except {α} : list α → ℕ → string → io α := λ xs po
   | none := do
     io.fail' format!"must supply {msg} as argument {pos}"
   end
+
+

--- a/src/util/tactic.lean
+++ b/src/util/tactic.lean
@@ -98,37 +98,6 @@ nms.mmap' add_open_namespace
 
 end add_open_namespace
 
-section full_names
-
-namespace tactic
-
-meta def enable_full_names : tactic unit := do {
-  set_bool_option `pp.full_names true
-}
-
-meta def with_full_names {α} (tac : tactic α) : tactic α :=
-tactic.save_options $ enable_full_names *> tac
-
-end tactic
-
-meta def tactic_state.fully_qualified (ts : tactic_state) : tactic tactic_state := do {
-  ts₀ ← tactic.read,
-  tactic.write ts,
-  result_ts ← tactic.with_full_names $ tactic.read,
-  tactic.write ts₀,
-  pure result_ts
-}
-
-meta def tactic_state.fully_qualified_string (ts : tactic_state) : tactic string := do {
-  ts₀ ← tactic.read,
-  tactic.write ts,
-  result ← tactic.with_full_names $ (tactic.read >>= λ ts, pure ts.to_format.to_string),
-  tactic.write ts₀,
-  pure result
-}
-
-end full_names
-
 section tactic_state
 open interaction_monad.result
 setup_tactic_parser

--- a/src/util/tactic.lean
+++ b/src/util/tactic.lean
@@ -105,35 +105,10 @@ setup_tactic_parser
 meta def num_goals' : tactic_state → option ℕ :=
 λ ts, match tactic.num_goals ts with | (success val _) := pure val | _ := none end
 
--- TODO(jesse): this is a hack. might be better to do this in python
-meta def consume_with_parser {α} (p : lean.parser α) : string → io string := λ inp, do {
-  io.run_tactic'' $ do
-    prod.snd <$> lean.parser.run (with_input p inp)
-}
-
--- TODO(jesse): performance
-meta def consume_spaces : string → string
-| arg@⟨[]⟩ := arg
-| arg@⟨(x::xs)⟩ := if x = ' ' then consume_spaces ⟨xs⟩ else arg
-
--- WARNING: this is a hack
-meta def remove_indents_with_split (c : char := '\t'): string → string := λ str,
-let strs := str.split (= '\t') in
-string.intercalate (⟨['\t']⟩ : string) (consume_spaces <$> strs)
-
-meta def postprocess_tactic_state : tactic_state → tactic string := λ ts, do
-  let main : tactic string := do {
-    let ts_str := "\\\"".intercalate (ts.to_format.to_string.split (= '"')),
-    tabbed_ts_str ← do {
-      if (num_goals' ts).get_or_else 0 ≤ 1
-      then pure $ ts_str.replace_char '\n' '\t'
-      else tactic.unsafe_run_io $ (λ x, string.replace_char x '\n' '\t')
-             <$> (consume_with_parser small_nat >=>
-               consume_with_parser ident) ts_str},
-    pure $ remove_indents_with_split '\t' tabbed_ts_str
-  },
-  main <|> (let msg := "[postprocess_tactic_state] WARNING: POSTPROCESSING FAILED" in
-    tactic.trace msg *> tactic.fail msg)
+meta def postprocess_tactic_state (ts : tactic_state) : tactic string := do
+  -- Note: we do not postprocess here, because we assume that there are other
+  -- data sources that use default `pp` settings.
+  pure $ to_string (to_fmt ts)
 
 end tactic_state
 


### PR DESCRIPTION
Strip unused `have` statements (and their proofs) from proofs. Note: only lightly tested.