### PR TITLE
Make scripts fail fast

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 # run from project root
 

--- a/scripts/setup_mathlib.sh
+++ b/scripts/setup_mathlib.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 # run from project root
 

--- a/scripts/setup_miniF2F.sh
+++ b/scripts/setup_miniF2F.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 # run from project root
 


### PR DESCRIPTION
When using it (incorrectly), I got something like 

```
mv: rename ./_target/deps/mathlib/src/all.lean to ./_target/deps/minif2f/lean/src/all.lean: No such file or directory
./scripts/setup.sh: line 15: ./_target/deps/minif2f/lean/src/all.lean: No such file or directory
./scripts/setup.sh: line 16: ./_target/deps/minif2f/lean/src/all.lean: No such file or directory
```

However, the script continues running and thus it is easy for users not to realize this problem. Thus, to follow the best practices of shell scripting, I add the flags to make it fail fast.